### PR TITLE
Add currency allow list proposal

### DIFF
--- a/proposals/2022-07-currency-allow-list/README.md
+++ b/proposals/2022-07-currency-allow-list/README.md
@@ -1,0 +1,31 @@
+# Currency Allow List Criteria
+
+This is a text proposal for the community to adopt a set of criteria as guidelines when evaluating future governance proposals to enable specific currencies in Regen Network's on-chain marketplace.
+
+- A Yes result on the proposal would provide a clear signal that the Regen Network community accepts the following as guidelines for evaluation criteria when discussing and voting to enable currencies in the allow list for use in Regen Network's ecocredit marketplace.
+
+- A No result on the proposal would force reconsideration of the criteria as outlined here.
+
+## Background
+
+Regen Ledger v4.0 includes a new on-chain marketplace that enables ecocredits to be listed for sale by their owners. In other words, a user who has ecocredits (unretired) in their account can list any number of their credits for sale (creating a standing "sell order"). The credits are escrowed on-chain, and another user can purchase up to the full quantity of credits in the sell order at the specified price.
+
+In order to prevent fragmented markets and an over-complicated end-user experience, credits cannot be listed in the marketplace in any currency at all. Rather, the listed of allowed "currencies" that ecocredits can be listed for sale in is controlled through on-chain governance.
+
+The desire from the team at RND, Inc is to have this list be relatively small, but leave the explicit control of which currencies to enable in the marketplace up to the Regen Network token holders.
+
+That being said, we (at RND, Inc) would like to propose a set of criteria for the community to use when evaluating accepting newly proposed currencies for use in the ecocredit marketplace. The initial conversation was started on the forum [here](https://commonwealth.im/regen/discussion/4959-adding-tokens-to-the-regen-ledger-currency-allow-list), and are now contuinuing that conversation in the from of this on-chain governance proposal.
+
+## Allow List Criteria
+
+We propose there are four major criteria for the analysis of any token applying to the Regen Network community:
+1. Is the token in question a currency?
+2. Is the token in question IBC compatible?
+3. Is the token in question liquid, stable and safe to use?
+4. Does the token support a good onboarding experience for non crypto natives?
+
+In addition to these criteria we would propose the following principles for consideration:
+1. **Ethical alignment with Regen Network aims**: Is the currency in question something that supports or enables a better world, and most specifically ecological regeneration?
+2. **Virtuous cycle with Regen Network's Ecocredits or other ecological asset types**: Examples of this include opportunities for inclusion of ecocredits into a stable coin's collateral system
+
+While there are no specific requirements around to what extent a currency must adhere to the above critera, we encourage deliberation and evaluation of currencies in the allow list to be focused on these criteria as discussion points.

--- a/proposals/2022-07-currency-allow-list/README.md
+++ b/proposals/2022-07-currency-allow-list/README.md
@@ -10,11 +10,11 @@ This is a text proposal for the community to adopt a set of criteria as guidelin
 
 Regen Ledger v4.0 includes a new on-chain marketplace that enables ecocredits to be listed for sale by their owners. In other words, a user who has ecocredits (unretired) in their account can list any number of their credits for sale (creating a standing "sell order"). The credits are escrowed on-chain, and another user can purchase up to the full quantity of credits in the sell order at the specified price.
 
-In order to prevent fragmented markets and an over-complicated end-user experience, credits cannot be listed in the marketplace in any currency at all. Rather, the listed of allowed "currencies" that ecocredits can be listed for sale in is controlled through on-chain governance.
+In order to prevent fragmented markets and an over-complicated end-user experience, credits cannot be listed in the marketplace in any currency at all. Rather, the listed of allowed "currencies" that ecocredits can be listed for sale is controlled through on-chain governance.
 
 The desire from the team at RND, Inc is to have this list be relatively small, but leave the explicit control of which currencies to enable in the marketplace up to the Regen Network token holders.
 
-That being said, we (at RND, Inc) would like to propose a set of criteria for the community to use when evaluating accepting newly proposed currencies for use in the ecocredit marketplace. The initial conversation was started on the forum [here](https://commonwealth.im/regen/discussion/4959-adding-tokens-to-the-regen-ledger-currency-allow-list), and are now contuinuing that conversation in the from of this on-chain governance proposal.
+That being said, we (at RND, Inc) would like to propose a set of criteria for the community to use when evaluating and accepting newly proposed currencies for use in the ecocredit marketplace. The initial conversation was started on the forum [here](https://commonwealth.im/regen/discussion/4959-adding-tokens-to-the-regen-ledger-currency-allow-list), and we are now continuing that conversation in the from of this on-chain governance proposal.
 
 ## Allow List Criteria
 
@@ -22,10 +22,10 @@ We propose there are four major criteria for the analysis of any token applying 
 1. Is the token in question a currency?
 2. Is the token in question IBC compatible?
 3. Is the token in question liquid, stable and safe to use?
-4. Does the token support a good onboarding experience for non crypto natives?
+4. Does the token support a good onboarding experience for non-crypto natives?
 
 In addition to these criteria we would propose the following principles for consideration:
 1. **Ethical alignment with Regen Network aims**: Is the currency in question something that supports or enables a better world, and most specifically ecological regeneration?
-2. **Virtuous cycle with Regen Network's Ecocredits or other ecological asset types**: Examples of this include opportunities for inclusion of ecocredits into a stable coin's collateral system
+2. **Virtuous cycle with Regen Network's Ecocredits or other ecological asset types**: Examples of this include opportunities for inclusion of ecocredits into a stable coin's collateral system.
 
 While there are no specific requirements around to what extent a currency must adhere to the above critera, we encourage deliberation and evaluation of currencies in the allow list to be focused on these criteria as discussion points.

--- a/proposals/2022-07-currency-allow-list/proposal.json
+++ b/proposals/2022-07-currency-allow-list/proposal.json
@@ -1,0 +1,5 @@
+{
+    "type": "Text",
+    "title": "Adoption of Currency Allow List Criteria",
+    "description": "This is a text proposal for the community to adopt a set of criteria as guidelines when evaluating future governance proposals to enable specific currencies in Regen Network's on-chain marketplace.\n\nMore information can be found in the long-form proposal: https://github.com/regen-network/governance/tree/main/proposals/2022-07-currency-allow-list"
+}


### PR DESCRIPTION
This adds an on-chain proposal for community alignment on guidelines when enabling tokens into the ecocredit marketplace currency allow list, as originally outlined in this [forum post](https://commonwealth.im/regen/discussion/4959-adding-tokens-to-the-regen-ledger-currency-allow-list).